### PR TITLE
Add optional environment parameter to set max length of stacktrace

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.2.0 (unreleased)
+------------------
+- Add optional environment parameter to set max length of stacktrace ("SENTRY_MAX_LENGTH", default is 512)
+  [Thokas]
+
 0.1.7 (2019/10/21)
 ------------------
 - Make collective.sentry configuration optional (do not load if no **SENTRY_DSN**)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,3 +2,4 @@ Contributors
 ------------
 
 - Andreas Jung <info@zopyx.com>
+- Thomas Kastenholz <github@kronix.eu>

--- a/setup.py
+++ b/setup.py
@@ -5,39 +5,42 @@ collective.sentry
 import os
 from setuptools import setup, find_packages
 
+
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '0.1.7'
+
+version = '0.2.0'
 
 long_description = (
-    read('README.txt')
-    + '\n' +
-    read('CHANGES.txt')
-    + '\n' +
-    read('CONTRIBUTORS.txt')
-    )
+        read('README.txt')
+        + '\n' +
+        read('CHANGES.txt')
+        + '\n' +
+        read('CONTRIBUTORS.txt')
+)
 
 setup(name='collective.sentry',
       version=version,
       description="Sentry integration with Plone 5.2/Zope 4",
       long_description=long_description,
-      # Get more strings from http://www.python.org/pypi?%3Aaction=list_classifiers
+      # Get more strings from
+      # http://www.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[
-        "Framework :: Plone",
-        "Intended Audience :: Developers",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "License :: OSI Approved :: GNU General Public License (GPL)",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Framework :: Plone",
-        "Framework :: Plone :: 5.1",
-        "Framework :: Plone :: 5.2",
-        "Framework :: Zope",
-        "Framework :: Zope :: 4",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        ],
+          "Framework :: Plone",
+          "Intended Audience :: Developers",
+          "Topic :: Software Development :: Libraries :: Python Modules",
+          "License :: OSI Approved :: GNU General Public License (GPL)",
+          "Programming Language :: Python",
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Framework :: Plone",
+          "Framework :: Plone :: 5.1",
+          "Framework :: Plone :: 5.2",
+          "Framework :: Zope",
+          "Framework :: Zope :: 4",
+          "Topic :: Software Development :: Libraries :: Python Modules",
+      ],
       keywords='policy',
       author='Andreas Jung',
       author_email='info@zopyx.com',


### PR DESCRIPTION
I've tried to use the Package in our new sentry environment with Plone 5.2/Python3.6 and encountered the problem that the stacktrace gets cut after 512 characters.
Probably not the best solution, but for the moment the best i could come up with :flushed: