### PR TITLE
Add optional environment parameter to blacklist cookies

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Unreleased
+------------------
+- Add optional enviroment parameter to filter cookies
+
 0.2.0 (2019/11/28)
 ------------------
 - Add optional environment parameter to set max length of stacktrace ("SENTRY_MAX_LENGTH", default is 512)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,7 +3,8 @@ Changelog
 
 Unreleased
 ------------------
-- Add optional enviroment parameter to filter cookies
+- Add optional environment parameter to blacklist cookies. To prevent the Add-on e.g from sending the __ac cookie to sentry. Blacklist cookie names separated by a semicolon (e.g COOKIES_FILTER_BLACKLIST cookiename1;cookiename2)
+  [Nimo-19]
 
 0.2.0 (2019/11/28)
 ------------------

--- a/collective/sentry/error_handler.py
+++ b/collective/sentry/error_handler.py
@@ -23,8 +23,6 @@ is_sentry_optional = os.environ.get("SENTRY_OPTIONAL")
 
 sentry_max_length = os.environ.get("SENTRY_MAX_LENGTH")
 
-# Blacklist cookie names seperated with a semicolon
-# COOKIES_FILTER_BLACKLIST cookiename1;cookiename2
 cookies_filter_blacklist = os.environ.get("COOKIES_FILTER_BLACKLIST")
 
 


### PR DESCRIPTION
This adds the ability to prevent the addon from sending the blacklisted cookies to sentry.
It is set via the environment-va COOKIES_FILTER_BLACKLIST in form of a semicolon seperated list
(e.g COOKIES_FILTER_BLACKLIST mycookietest;mycookietest2)

We recently needed this capability to blacklist the __ac cookie to prevent the Add-on from sending it to sentry.