### PR TITLE
Send optional "environment" metadata to sentry 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 Changelog
 =========
+Unreleased
+----------
+- Add SENTRY_ENVIRONMENT option.
+  [fulv]
 
 0.2.0 (2019/11/28)
 ------------------

--- a/README.txt
+++ b/README.txt
@@ -32,6 +32,10 @@ additional tag `project` can be configured (optional) if you set the
 environment variable `SENTRY_PROJECT`.  This allows you introduce an additional
 tag for filtering, if needed.
 
+Another option for filtering is `SENTRY_ENVIRONMENT`, useful to differentiate 
+between e.g. staging vs production 
+(https://docs.sentry.io/enriching-error-data/environments/?platform=python).
+
 
 Optional activation
 ---------------------

--- a/collective/sentry/error_handler.py
+++ b/collective/sentry/error_handler.py
@@ -19,6 +19,8 @@ sentry_dsn = os.environ.get("SENTRY_DSN")
 
 sentry_project = os.environ.get("SENTRY_PROJECT")
 
+sentry_environment = os.environ.get("SENTRY_ENVIRONMENT")
+
 is_sentry_optional = os.environ.get("SENTRY_OPTIONAL")
 
 sentry_max_length = os.environ.get("SENTRY_MAX_LENGTH")
@@ -118,7 +120,8 @@ if sentry_dsn:
         sentry_dsn,
         max_breadcrumbs=50,
         before_send=before_send,
-        debug=False
+        debug=False,
+        environment=sentry_environment,
     )
 
     configuration = getConfiguration()


### PR DESCRIPTION
https://docs.sentry.io/enriching-error-data/environments/?platform=python

For example, to distinguish issues between production and staging deployments.

I have this running in production, works fine.