### PR TITLE
Send exceptions to sentry directly w/o using logging

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -32,6 +32,10 @@ additional tag `project` can be configured (optional) if you set the
 environment variable `SENTRY_PROJECT`.  This allows you introduce an additional
 tag for filtering, if needed.
 
+Set `SENTRY_ENVIRONMENT` to differentiate between environments e.g. staging vs production 
+(https://docs.sentry.io/enriching-error-data/environments/)
+
+Set `SENTRY_RELEASE` to sent release information to sentry. (https://docs.sentry.io/workflow/releases/)
 
 Optional activation
 ---------------------

--- a/collective/sentry/configure.zcml
+++ b/collective/sentry/configure.zcml
@@ -8,5 +8,5 @@
     xmlns:plone="http://namespaces.plone.org/plone"
     >
 
-    <subscriber handler=".error_handler.dummy"/>
+    <subscriber handler=".error_handler.errorRaisedSubscriber"/>
 </configure>

--- a/collective/sentry/error_handler.py
+++ b/collective/sentry/error_handler.py
@@ -35,11 +35,6 @@ is_sentry_optional = os.environ.get("SENTRY_OPTIONAL")
 
 sentry_max_length = os.environ.get("SENTRY_MAX_LENGTH")
 
-sentry_environment = os.environ.get("SENTRY_ENVIRONMENT")
-
-sentry_release = os.environ.get("SENTRY_RELEASE")
-
-
 def _get_user_from_request(request):
     user = request.get("AUTHENTICATED_USER", None)
     if user is not None and user != nobody:
@@ -162,16 +157,13 @@ if sentry_dsn:
         max_breadcrumbs=50,
         before_send=before_send,
         attach_stacktrace=True,
-        debug=False,
-        release=sentry_release
+        debug=False
     )
 
     configuration = getConfiguration()
     tags = {}
     instancehome = configuration.instancehome
     tags['instance_name'] = instancehome.rsplit(os.path.sep, 1)[-1]
-    if sentry_environment:
-        tags['environment']  = sentry_environment
 
     with sentry_sdk.configure_scope() as scope:
         for k, v in tags.items():

--- a/collective/sentry/error_handler.py
+++ b/collective/sentry/error_handler.py
@@ -3,17 +3,20 @@
 # Integration of Zope (4) with Sentry
 # The code below is heavily based on the raven.contrib. zope module
 
-import os
 import logging
-import traceback
+import os
 import sys
+import traceback
+
 import sentry_sdk
 import sentry_sdk.utils as sentry_utils
-
+from AccessControl.users import nobody
 from App.config import getConfiguration
+from sentry_sdk.integrations.logging import ignore_logger
 from zope.component import adapter
 from zope.globalrequest import getRequest
-from AccessControl.users import nobody
+from ZPublisher.HTTPRequest import _filterPasswordFields
+
 try:
     from Products.SiteErrorLog.interfaces import IErrorRaisedEvent
     EventInterface = IErrorRaisedEvent
@@ -23,8 +26,6 @@ except ImportError:
     from ZPublisher.interfaces import IPubFailure
     EventInterface = IPubFailure
 
-from ZPublisher.HTTPRequest import _filterPasswordFields
-from sentry_sdk.integrations.logging import ignore_logger
 
 sentry_dsn = os.environ.get("SENTRY_DSN")
 

--- a/collective/sentry/error_handler.py
+++ b/collective/sentry/error_handler.py
@@ -35,6 +35,10 @@ is_sentry_optional = os.environ.get("SENTRY_OPTIONAL")
 
 sentry_max_length = os.environ.get("SENTRY_MAX_LENGTH")
 
+sentry_environment = os.environ.get("SENTRY_ENVIRONMENT")
+
+sentry_release = os.environ.get("SENTRY_RELEASE")
+
 
 def _before_send(event, hint):
     """
@@ -131,13 +135,16 @@ if sentry_dsn:
         max_breadcrumbs=50,
         before_send=before_send,
         attach_stacktrace=True,
-        debug=False
+        debug=False,
+        release=sentry_release
     )
 
     configuration = getConfiguration()
     tags = {}
     instancehome = configuration.instancehome
     tags['instance_name'] = instancehome.rsplit(os.path.sep, 1)[-1]
+    if sentry_environment:
+        tags['environment']  = sentry_environment
 
     with sentry_sdk.configure_scope() as scope:
         for k, v in tags.items():


### PR DESCRIPTION
@nimo-19 found out that the reason for our sentry errors not being grouped correctly (see https://github.com/collective/collective.sentry/issues/5) ) is that python sentry sdk hooks into logging by default. All log messages are created at https://github.com/zopefoundation/Products.SiteErrorLog/blob/82f85a64b1451bacb9df9087855e4e2d5269ef6a/src/Products/SiteErrorLog/SiteErrorLog.py#L252. 
=> Because of that all errors sentry see have the same stack trace and sentry [groups by stack trace](https://docs.sentry.io/data-management/event-grouping/#grouping-by-stacktrace).

We registered a subscriber to `Products.SiteErrorLog.interfaces.IErrorRaisedEvent` (`ZPublisher.interfaces.IPubFailure` for Plone 5.1) and directly send the exceptions to sentry without using logging.

In addition we told sentry sdk to ignore "Zope.SiteErrorLog" logger to prevent doubled errors.

Now grouping works as expected in sentry.

Hopefully someone can review our code b/c we are not 100% sure if the events we subscribed to are sufficient to really catch all errors.

In addition we have added environment variables `SENTRY_ENVIRONMENT` and `SENTRY_RELEASE` to send information about "environment" and "release" to sentry. (I saw https://github.com/collective/collective.sentry/pull/4 to late - but both changes should be compatible)
