### PR TITLE
Ignore exceptions that are ignored in the root Zope error_log.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,12 +5,13 @@ Changelog
 0.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Ignore exceptions that are ignored in the root Zope error_log.
+  [maurits]
 
 
 0.2.3 (2020/08/05)
 ------------------
-- Fix error handling on zope site root 
+- Fix error handling on zope site root
   [krissik]
 
 0.2.2 (2020/07/13)

--- a/collective/sentry/error_handler.py
+++ b/collective/sentry/error_handler.py
@@ -189,7 +189,11 @@ def errorRaisedSubscriber(event):
     try:
         error_log = api.portal.get_tool(name="error_log")
     except CannotGetPortalError:
-        error_log = None
+        # Try to get Zope root.
+        try:
+            error_log = event.request.PARENTS[0].error_log
+        except (AttributeError, KeyError, IndexError):
+            error_log = None
 
     if error_log and exc_info[0].__name__ in error_log._ignored_exceptions:
         return


### PR DESCRIPTION
With the latest changes, the `ignored_exceptions` attribute of the Plone error_log was taken into account,
but the code did not yet try to check the Zope error_log for `ignored_exceptions`.