### PR TITLE
Ignore all ignored exceptions configured in the error log settings

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ UNRELEASED
 
 - Add optional environment parameter for Sentry integrations ("SENTRY_INTEGRATIONS", comma seperated list)
   [2silver]
+- Ensure all exceptions which should be ignored are actually ignored before sending them.
+  [thomasmassmann]
 
 
 0.2.4 (2020/09/07)


### PR DESCRIPTION
This also ignores the errors which can happen during the publication process, but don’t raise a publication error.

See #11 for details.