### PR TITLE
Removed unxpected keyword on SENTRY_MAX_LENGTH

### DIFF
--- a/collective/sentry/error_handler.py
+++ b/collective/sentry/error_handler.py
@@ -30,7 +30,7 @@ sentry_environment = os.environ.get("SENTRY_ENVIRONMENT")
 
 is_sentry_optional = os.environ.get("SENTRY_OPTIONAL")
 
-sentry_max_length = int(os.environ.get("SENTRY_MAX_LENGTH", default=512))
+sentry_max_length = int(os.environ.get("SENTRY_MAX_LENGTH", 512))
 
 sentry_disable = os.environ.get("SENTRY_DISABLE") or False
 


### PR DESCRIPTION
Refers to issue https://github.com/collective/collective.sentry/issues/24
Removed unexpected keyword default on SENTRY_MAX_LENGTH