### PR TITLE
Plone 6.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 #
 # EditorConfig Configuration file, for more details see:

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [flake8]
 doctests = 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 version: 2
 updates:

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,16 +1,10 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Meta
+
 on:
   push:
-    branches:
-      - master
-      - main
-  pull_request:
-    branches:
-      - master
-      - main
   workflow_dispatch:
 
 ##

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,0 +1,65 @@
+# Generated from:
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
+# See the inline comments on how to expand/tweak this configuration file
+name: Tests
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    permissions:
+      contents: read
+      pull-requests: write
+    strategy:
+      # We want to see all failures:
+      fail-fast: false
+      matrix:
+        os:
+        - ["ubuntu", "ubuntu-latest"]
+        config:
+        # [Python version, visual name, tox env]
+        - ["3.14", "6.2 on py3.14", "py314-plone62"]
+        - ["3.10", "6.2 on py3.10", "py310-plone62"]
+
+    runs-on: ${{ matrix.os[1] }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    name: ${{ matrix.config[1] }}
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - name: Install uv + caching
+      uses: astral-sh/setup-uv@v8.1.0
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          setup.*
+          tox.ini
+          pyproject.toml
+        python-version: ${{ matrix.config[0] }}
+
+##
+# Add extra configuration options in .meta.toml:
+#  [github]
+#  extra_lines_after_os_dependencies = """
+#  _your own configuration lines_
+#  """
+##
+    - name: Initialize tox
+      # the bash one-liner below does not work on Windows
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        if [ `uvx tox list --no-desc -f init|wc -l` = 1 ]; then uvx --with tox-uv tox -e init;else true; fi
+    - name: Test
+      run: uvx --with tox-uv tox -e ${{ matrix.config[2] }}
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [github]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 # python related
 *.egg-info

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,9 +1,9 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "2.2.3.dev0"
+commit-id = "2.9.0"
 
 [github]
 jobs = [
@@ -12,3 +12,7 @@ jobs = [
    "release_ready",
    "circular",
 ]
+
+[tox]
+test_matrix = {"6.2" = ["*"]}
+skip_test_extra = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 ci:
     autofix_prs: false
@@ -7,20 +7,20 @@ ci:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py310-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 7.0.0
+    rev: 9.0.0a3
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.9.0
+    rev: 26.3.1
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
-    rev: 3.1.1
+    rev: 4.0.0
     hooks:
     -   id: zpretty
 
@@ -44,7 +44,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
     -   id: codespell
         additional_dependencies:
@@ -62,16 +62,16 @@ repos:
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/regebro/pyroma
-    rev: "5.0"
+    rev: "5.0.1"
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.23.0"
+    rev: "0.24.2"
     hooks:
     -   id: check-python-versions
-        args: ['--only', 'setup.py,pyproject.toml']
+        args: ['--only', 'setup.py,tox.ini']
 -   repo: https://github.com/collective/i18ndude
-    rev: "6.2.1"
+    rev: "6.3.0"
     hooks:
     -   id: i18ndude
 

--- a/news/3928.breaking
+++ b/news/3928.breaking
@@ -1,0 +1,2 @@
+Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+Support only Plone 6.2 and Python 3.10+.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [build-system]
-requires = ["setuptools>=68.2,<80", "wheel"]
+requires = ["setuptools>=68.2,<83", "wheel"]
+
+
 
 [tool.towncrier]
 directory = "news/"
@@ -60,7 +62,7 @@ profile = "plone"
 ##
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py310"]
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "Tracker": "https://github.com/collective/collective.sentry/issues",
     },
     zip_safe=False,
-    install_requires=["setuptools", "sentry-sdk>2.27.0", "Zope", "plone.api"],
+    install_requires=["sentry-sdk>2.27.0", "Zope", "plone.api"],
     entry_points="""
       # -*- Entry points -*-
       [z3c.autoinclude.plugin]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     version=version,
     description="Sentry integration with Plone 5.2/Zope 4",
     long_description=long_description,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     # Get more strings from
     # http://www.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
@@ -30,12 +30,12 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Framework :: Plone",
         "Framework :: Plone :: 6.0",
         "Framework :: Plone :: 6.1",

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,7 @@ setup(
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",
         "Framework :: Plone",
-        "Framework :: Plone :: 6.0",
-        "Framework :: Plone :: 6.1",
+        "Framework :: Plone :: 6.2",
         "Framework :: Zope",
         "Framework :: Zope :: 5",
         "Topic :: Software Development :: Libraries :: Python Modules",
@@ -47,11 +46,6 @@ setup(
     author="Andreas Jung",
     author_email="info@zopyx.com",
     license="GPL",
-    packages=["collective", "collective.sentry"],
-    package_dir={"": "src"},
-    namespace_packages=[
-        "collective",
-    ],
     include_package_data=True,
     project_urls={
         "Code": "https://github.com/collective/collective.sentry",

--- a/src/collective/__init__.py
+++ b/src/collective/__init__.py
@@ -1,7 +1,0 @@
-# See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
-try:
-    __import__("pkg_resources").declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-
-    __path__ = extend_path(__path__, __name__)

--- a/src/collective/sentry/error_handler.py
+++ b/src/collective/sentry/error_handler.py
@@ -21,7 +21,6 @@ import sentry_sdk
 import sentry_sdk.utils as sentry_utils
 import sys
 
-
 sentry_dsn = os.environ.get("SENTRY_DSN")
 
 sentry_project = os.environ.get("SENTRY_PROJECT")

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,17 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [tox]
 # We need 4.4.0 for constrain_package_deps.
 min_version = 4.4.0
 envlist =
     lint
+    test
+    py314-plone62
+    py313-plone62
+    py312-plone62
+    py311-plone62
+    py310-plone62
     dependencies
 
 
@@ -13,6 +19,7 @@ envlist =
 # Add extra configuration options in .meta.toml:
 # - to specify a custom testing combination of Plone and python versions, use `test_matrix`
 #   Use ["*"] to use all supported Python versions for this Plone version.
+# - to disable the test matrix entirely, set `use_test_matrix = false`
 # - to specify extra custom environments, use `envlist_lines`
 # - to specify extra `tox` top-level options, use `config_lines`
 #  [tox]
@@ -57,9 +64,9 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
-    z3c.dependencychecker==2.14.3
+    z3c.dependencychecker==3.0
 commands =
-    python -m build --sdist
+    python -m build --wheel
     dependencychecker
 
 [testenv:dependencies-graph]
@@ -72,6 +79,109 @@ deps =
     graphviz  # optional dependency of pipdeptree
 commands =
     sh -c 'pipdeptree --exclude setuptools,wheel,pipdeptree,zope.interface,zope.component --graph-output svg > dependencies.svg'
+
+
+[test_runner]
+deps = zope.testrunner
+test =
+    zope-testrunner --all --test-path={toxinidir}/src -s collective.sentry {posargs}
+coverage =
+    coverage run --branch --source collective.sentry {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir}/src -s collective.sentry {posargs}
+    coverage report -m --format markdown
+    coverage xml
+    coverage html
+
+[base]
+description = shared configuration for tests and coverage
+use_develop = true
+skip_install = false
+constrain_package_deps = true
+set_env =
+    ROBOT_BROWSER=headlesschrome
+
+##
+# Specify extra test environment variables in .meta.toml:
+#  [tox]
+#  test_environment_variables = """
+#      PIP_EXTRA_INDEX_URL=https://my-pypi.my-server.com/
+#  """
+#
+# Set constrain_package_deps .meta.toml:
+#  [tox]
+#  constrain_package_deps = false
+##
+deps =
+    {[test_runner]deps}
+    plone62: -c https://dist.plone.org/release/6.2-dev/constraints.txt
+
+##
+# Specify additional deps in .meta.toml:
+#  [tox]
+#  test_deps_additional = """
+#     -esources/plonegovbr.portal_base[test]
+#  """
+#
+# Specify a custom constraints file in .meta.toml:
+#  [tox]
+#  constraints_file = "https://my-server.com/constraints.txt"
+##
+extras =
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  skip_test_extra = true
+#  test_extras = """
+#      tests
+#      widgets
+#  """
+#
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  testenv_options = """
+#  basepython = /usr/bin/python3.8
+#  """
+##
+
+[testenv:test]
+description = run the distribution tests
+use_develop = {[base]use_develop}
+skip_install = {[base]skip_install}
+constrain_package_deps = {[base]constrain_package_deps}
+set_env = {[base]set_env}
+deps =
+    {[test_runner]deps}
+    -c https://dist.plone.org/release/6.2-dev/constraints.txt
+
+commands = {[test_runner]test}
+extras = {[base]extras}
+
+
+[testenv]
+description = run the distribution tests (generative environments)
+use_develop = {[base]use_develop}
+skip_install = {[base]skip_install}
+constrain_package_deps = {[base]constrain_package_deps}
+set_env = {[base]set_env}
+deps = {[base]deps}
+commands = {[test_runner]test}
+extras = {[base]extras}
+
+
+[testenv:coverage]
+description = get a test coverage report
+use_develop = {[base]use_develop}
+skip_install = {[base]skip_install}
+constrain_package_deps = {[base]constrain_package_deps}
+set_env = {[base]set_env}
+deps =
+    {[test_runner]deps}
+    coverage
+    -c https://dist.plone.org/release/6.2-dev/constraints.txt
+
+commands = {[test_runner]coverage}
+extras = {[base]extras}
 
 
 [testenv:release-check]


### PR DESCRIPTION
- update to latest `plone.meta`
- use native namespaces